### PR TITLE
Fix "No such file or directory: 'RUNS/KittiSeg_pretrained.zip'"

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -83,11 +83,12 @@ def maybe_download_and_extract(runs_dir):
         # weights are downloaded. Nothing to do
         return
 
-    import zipfile
+    os.mkdirs(runs_dir)
+    
     download_name = tv_utils.download(weights_url, runs_dir)
-
     logging.info("Extracting KittiSeg_pretrained.zip")
 
+    import zipfile
     zipfile.ZipFile(download_name, 'r').extractall(runs_dir)
 
     return

--- a/demo.py
+++ b/demo.py
@@ -82,9 +82,9 @@ def maybe_download_and_extract(runs_dir):
     if os.path.exists(logdir):
         # weights are downloaded. Nothing to do
         return
-
-    os.mkdirs(runs_dir)
-    
+      
+    if not os.path.exists(runs_dir):
+        os.makedirs(runs_dir)
     download_name = tv_utils.download(weights_url, runs_dir)
     logging.info("Extracting KittiSeg_pretrained.zip")
 


### PR DESCRIPTION
create the "RUNS" directory to fix https://github.com/MarvinTeichmann/KittiSeg/issues/19: No such file or directory: 'RUNS/KittiSeg_pretrained.zip'.

The root cause is that `open()` does not create a file when the file should be created in other directories. Users have to create the directories first.