### PR TITLE
Perform random hue/saturation on >1 batch sizes

### DIFF
--- a/inputs/kitti_seg_input.py
+++ b/inputs/kitti_seg_input.py
@@ -442,8 +442,8 @@ def _processe_image(hypes, image):
         image = tf.image.random_brightness(image, max_delta=30)
         image = tf.image.random_contrast(image, lower=0.75, upper=1.25)
     if augment_level > 1:
-        image = tf.image.random_hue(image, max_delta=0.15)
-        image = tf.image.random_saturation(image, lower=0.5, upper=1.6)
+        image = tf.map_fn(lambda img: tf.image.random_hue(img, max_delta=0.15), image)
+        image = tf.map_fn(lambda img: tf.image.random_saturation(img, lower=0.5, upper=1.6), image)
 
     return image
 


### PR DESCRIPTION
Random_hue and saturation will error out when the tensor rank is not 3.

This will perform the operations with no error on all images in the batch.

Note: this is only available in tensorflow r1.4